### PR TITLE
Fix Choisissez un motif de déplacement - en dark mode

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -103,7 +103,7 @@ const createReasonFieldset = (reasonsData) => {
   const appendToFieldset = appendTo(fieldset)
 
   const legendAttrs = {
-    className: 'legend titre 3 ',
+    className: 'legend titre-3 ',
     innerHTML: 'Choisissez un motif de déplacement',
   }
   const legend = createElement('legend', legendAttrs)


### PR DESCRIPTION
Le texte n'est pas visible en dark mode - Choisissez un motif de déplacement. Fixé le nom de la classe généré par form.js