### PR TITLE
Enregistrer et restaurer automatiquement les données du formulaire (avec chiffrement)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,6 +3111,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
     "css-blank-pseudo": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
@@ -6184,6 +6189,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
     },
     "magic-string": {
       "version": "0.22.5",
@@ -9601,6 +9611,15 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.1.1"
+      }
+    },
+    "secure-ls": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/secure-ls/-/secure-ls-1.2.6.tgz",
+      "integrity": "sha512-g8vUSKl6elSfyAUHodybnNkuZW+mUYEOWj4SZIDg+xoQ1dq5ddktBoOFrtxQBUl88ZyAJOtGWQ1PRaOxkTAuZQ==",
+      "requires": {
+        "crypto-js": "^3.1.6",
+        "lz-string": "^1.4.4"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "bootstrap": "^4.5.3",
     "pdf-lib": "^1.11.2",
     "qrcode": "^1.4.4",
-    "remove-accents": "^0.4.2"
+    "remove-accents": "^0.4.2",
+    "secure-ls": "^1.2.6"
   },
   "browserslist": [
     "last 5 versions"

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -154,6 +154,10 @@ p {
   transform: translateY(-2px);
 }
 
+#form-profile #formgroup-storedata {
+  user-select: none;
+}
+
 @media (prefers-color-scheme: dark) {
   #form-profile .form-radio-label .form-check-label {
     color: #ddd;
@@ -350,6 +354,10 @@ input[type=number] {
   color: white;
   background-color: #000191;
   border-radius: 0.5em;
+}
+
+.delete-data-link {
+  text-align: center;
 }
 
 .btn-attestation:hover {
@@ -581,7 +589,7 @@ input[type=number] {
   }
 }
 
-#snackbar {
+#snackbar, #snackbar-cleardata {
   min-width: 250px;
   color: #fff;
   text-align: center;
@@ -598,7 +606,7 @@ input[type=number] {
   transition: all 0.5s ease-in-out;
 }
 
-#snackbar.show {
+#snackbar.show, #snackbar-cleardata.show {
   opacity: 1;
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -73,9 +73,7 @@
             <div class="bg-primary  d-none" id="snackbar">
                 L'attestation est téléchargée sur votre appareil.
             </div>
-        </div>
 
-        <div class="wrapper">
           <div id="formgroup-storedata"
                class="form-check text-center">
             <input class="form-check-input"
@@ -88,7 +86,6 @@
               Stocker mes données sur l'appareil afin de remplir automatiquement mes futures attestations
             </label>
           </div>
-        </div>
 
         <a id="cleardata"
            class="center delete-data-link"
@@ -100,9 +97,8 @@
     </div>
 
 
-    <div class="">
-        <p id="footnotes">
-            <span id="footnote1">
+        <div id="footnotes">
+            <p id="footnote1">
                 [1] Les personnes souhaitant bénéficier de l'une de ces exceptions doivent se munir s'il y a lieu, lors de leurs déplacements hors de leur domicile, d'un document leur permettant de justifier que le déplacement considéré entre dans le champ de l'une de ces exceptions.
             </p>
             <p id="footnote2">

--- a/src/index.html
+++ b/src/index.html
@@ -89,7 +89,7 @@
 
         <a id="cleardata"
            class="center delete-data-link"
-           href="javascript:void(0)">Effacer les données du formulaire ?</a>
+           href="javascript:void(0)">Effacer les données du formulaire</a>
         <div class="bg-primary  d-none"
              id="snackbar-cleardata">
           Les données du formulaire ont été effacées.

--- a/src/index.html
+++ b/src/index.html
@@ -84,7 +84,7 @@
                    id="field-storedata"
                    value="storedata">
             <label class="form-check-label"
-                   for="checkbox-storedata">
+                   for="field-storedata">
               Stocker mes données sur l'appareil afin de remplir automatiquement mes futures attestations
             </label>
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -46,8 +46,8 @@
                 </span>
             </h1>
             <p class="text-desc">
-                En application du décret n°2020-1310 du 29 octobre 2020 prescrivant les mesures générales 
-                nécessaires pour faire face à l'épidémie de Covid19 dans le cadre de l'état d'urgence sanitaire 
+                En application du décret n°2020-1310 du 29 octobre 2020 prescrivant les mesures générales
+                nécessaires pour faire face à l'épidémie de Covid19 dans le cadre de l'état d'urgence sanitaire
             </p>
 
         </div>
@@ -59,19 +59,50 @@
             id="alert-facebook"
         ></p>
 
-        <div class="wrapper">
-            <form id="form-profile" accept-charset="UTF-8"></form>
-            <p class="text-center mt-5">
-                <button type="button" id="generate-btn" class="btn btn-primary btn-attestation"><span ><i class="fa fa-file-pdf inline-block mr-1"></i>  Générer mon attestation</span></button>
-            </p>
+    <div class="wrapper">
+        <form id="form-profile" accept-charset="UTF-8"></form>
+        <p class="text-center mt-5">
+            <button type="button" id="generate-btn" class="btn btn-primary btn-attestation">
+              <span>
+                <i class="fa fa-file-pdf inline-block mr-1"></i>
+                Générer mon attestation
+              </span>
+            </button>
+        </p>
 
             <div class="bg-primary  d-none" id="snackbar">
                 L'attestation est téléchargée sur votre appareil.
             </div>
         </div>
 
-        <div id="footnotes">
-            <p id="footnote1">
+        <div class="wrapper">
+          <div id="formgroup-storedata"
+               class="form-check text-center">
+            <input class="form-check-input"
+                   type="checkbox"
+                   name="storedata"
+                   id="field-storedata"
+                   value="storedata">
+            <label class="form-check-label"
+                   for="checkbox-storedata">
+              Stocker mes données sur l'appareil afin de remplir automatiquement mes futures attestations
+            </label>
+          </div>
+        </div>
+
+        <a id="cleardata"
+           class="center delete-data-link"
+           href="javascript:void(0)">Effacer les données du formulaire ?</a>
+        <div class="bg-primary  d-none"
+             id="snackbar-cleardata">
+          Les données du formulaire ont été effacées.
+        </div>
+    </div>
+
+
+    <div class="">
+        <p id="footnotes">
+            <span id="footnote1">
                 [1] Les personnes souhaitant bénéficier de l'une de ces exceptions doivent se munir s'il y a lieu, lors de leurs déplacements hors de leur domicile, d'un document leur permettant de justifier que le déplacement considéré entre dans le champ de l'une de ces exceptions.
             </p>
             <p id="footnote2">

--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -136,13 +136,12 @@ export function getReasons (reasonInputs) {
 }
 
 export function getReasonsObject (reasonInputs) {
-  const reasons = reasonInputs
+  return reasonInputs
     .filter((reason) => reason.checked)
-    .reduce(function (map, reason) {
+    .reduce((map, reason) => {
       map[reason.value] = reason.checked
       return map
     }, {})
-  return reasons
 }
 
 export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar, releaseDateInput, releaseTimeInput) {

--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -76,6 +76,7 @@ function clearSecureLS () {
 function clearForm () {
   const formProfile = $('#form-profile')
   formProfile.reset()
+  storeDataInput.checked = false
 }
 
 function setCurrentDate (releaseDateInput, releaseTimeInput) {

--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -199,10 +199,6 @@ export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonA
     })
   })
 
-  $('#formgroup-storedata').addEventListener('click', () => {
-    (storeDataInput.checked) ? storeDataInput.checked = false : storeDataInput.checked = true
-  })
-
   $('#cleardata').addEventListener('click', () => {
     clearSecureLS()
     clearForm()

--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -4,6 +4,11 @@ import { $, $$, downloadBlob } from './dom-utils'
 import { addSlash, getFormattedDate } from './util'
 import pdfBase from '../certificate.pdf'
 import { generatePdf } from './pdf-util'
+import SecureLS from 'secure-ls'
+
+const secureLS = new SecureLS({ encodingType: 'aes' })
+const clearDataSnackbar = $('#snackbar-cleardata')
+const storeDataInput = $('#field-storedata')
 
 const conditions = {
   '#field-firstname': {
@@ -55,6 +60,45 @@ function validateAriaFields () {
     .includes(true)
 }
 
+function updateSecureLS (formInputs, reasonInputs) {
+  if (wantDataToBeStored() === true) {
+    secureLS.set('profile', getProfile(formInputs))
+    secureLS.set('reason', getReasonsObject(reasonInputs))
+  } else {
+    clearSecureLS()
+  }
+}
+
+function clearSecureLS () {
+  secureLS.clear()
+}
+
+function clearForm () {
+  const formProfile = $('#form-profile')
+  formProfile.reset()
+}
+
+function setCurrentDate (releaseDateInput, releaseTimeInput) {
+  const currentDate = new Date()
+
+  releaseDateInput.value = getFormattedDate(currentDate)
+  releaseTimeInput.value = currentDate.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+}
+
+function showSnackbar (snackbarToShow, showDuration = 6000) {
+  snackbarToShow.classList.remove('d-none')
+  setTimeout(() => snackbarToShow.classList.add('show'), 100)
+
+  setTimeout(function () {
+    snackbarToShow.classList.remove('show')
+    setTimeout(() => snackbarToShow.classList.add('d-none'), 500)
+  }, showDuration)
+}
+
+export function wantDataToBeStored () {
+  return storeDataInput.checked
+}
+
 export function setReleaseDateTime (releaseDateInput) {
   const loadedDate = new Date()
   releaseDateInput.value = getFormattedDate(loadedDate)
@@ -90,8 +134,40 @@ export function getReasons (reasonInputs) {
   return reasons
 }
 
-export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar) {
+export function getReasonsObject (reasonInputs) {
+  const reasons = reasonInputs
+    .filter((reason) => reason.checked)
+    .reduce(function (map, reason) {
+      map[reason.value] = reason.checked
+      return map
+    }, {})
+  return reasons
+}
+
+export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar, releaseDateInput, releaseTimeInput) {
+  const lsProfile = secureLS.get('profile')
+  const lsReason = secureLS.get('reason')
+  const currentDate = new Date()
+  const formattedDate = getFormattedDate(currentDate)
+  const formattedTime = currentDate.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+
+  // Continue to store data if already stored
+  storeDataInput.checked = lsReason || lsProfile
+
   formInputs.forEach((input) => {
+    switch (input.name) {
+      case 'datesortie':
+        input.value = formattedDate
+        break
+      case 'heuresortie':
+        input.value = formattedTime
+        break
+      case 'field-reason':
+        if (lsReason) input.checked = lsReason[input.value]
+        break
+      default:
+        if (lsProfile) input.value = lsProfile[input.name]
+    }
     const exempleElt = input.parentNode.parentNode.querySelector('.exemple')
     const validitySpan = input.parentNode.parentNode.querySelector('.validity')
     if (input.placeholder && exempleElt) {
@@ -123,6 +199,17 @@ export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonA
     })
   })
 
+  $('#formgroup-storedata').addEventListener('click', () => {
+    (storeDataInput.checked) ? storeDataInput.checked = false : storeDataInput.checked = true
+  })
+
+  $('#cleardata').addEventListener('click', () => {
+    clearSecureLS()
+    clearForm()
+    setCurrentDate(releaseDateInput, releaseTimeInput)
+    showSnackbar(clearDataSnackbar, 1200)
+  })
+
   $('#generate-btn').addEventListener('click', async (event) => {
     event.preventDefault()
 
@@ -138,6 +225,8 @@ export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonA
     if (invalid) {
       return
     }
+
+    updateSecureLS(formInputs, reasonInputs)
 
     const pdfBlob = await generatePdf(getProfile(formInputs), reasons, pdfBase)
 
@@ -166,6 +255,7 @@ export function prepareForm () {
   const reasonFieldset = $('#reason-fieldset')
   const reasonAlert = reasonFieldset.querySelector('.msg-alert')
   const releaseDateInput = $('#field-datesortie')
+  const releaseTimeInput = $('#field-heuresortie')
   setReleaseDateTime(releaseDateInput)
-  prepareInputs(formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar)
+  prepareInputs(formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar, releaseDateInput, releaseTimeInput)
 }

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -11,12 +11,6 @@ const createTitle = () => {
   const p = createElement('p', { className: 'msg-info', innerHTML: 'Tous les champs sont obligatoires.' })
   return [h2, p]
 }
-// createElement('div', { className: 'form-group' })
-
-const getCurrentTime = () => {
-  const date = new Date()
-  return date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
-}
 
 const createFormGroup = ({
   autocomplete = false,
@@ -59,10 +53,6 @@ const createFormGroup = ({
   }
 
   const input = createElement('input', inputAttrs)
-
-  if (name === 'heuresortie') {
-    input.value = getCurrentTime()
-  }
 
   const validityAttrs = {
     className: 'validity',


### PR DESCRIPTION
Reprise du travail fait par @theblackhole (https://github.com/LAB-MI/attestation-couvre-feu-covid-19/pull/4)
- Enregistrement chiffré des données du formulaire dans le localStorage à la génération du pdf
- Récupération des données chiffrées à l'ouverture du formulaire avec autocompletion des champs (profile et choix raison)
- Autocompletion de la date de sortie (avec date et heure actuelle)
- Ajout d'une checkbox pour choisir ou non d'enregister les données et d'un lien pour effacer les données enregistrées :
  - si la checkbox est décochée, les données sont effacées du localStorage mais pas du formulaire
  - si le lien pour effacer les données est cliqué, les données sont effacées du localStorage et du formulaire