### PR TITLE
Fix on Extra semicolon in form.js

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -14,8 +14,8 @@ const createTitle = () => {
 // createElement('div', { className: 'form-group' })
 
 const getCurrentTime = () => {
-  const date = new Date();
-  return date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+  const date = new Date()
+  return date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
 }
 
 const createFormGroup = ({


### PR DESCRIPTION
src/js/form.js
  17:26  error  Extra semicolon  semi
  18:82  error  Extra semicolon  semi

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.