### PR TITLE
readme : ajout informations de traçabilité

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Le code à déployer sera le contenu du dossier `dist`
 
 ## Crédits
 
-Ce projet a été réalisé à partir d'un fork du dépôt [deplacement-covid-19](https://github.com/nesk/deplacement-covid-19) de lui-même réalisé à partir d'un fork du dépôt [covid-19-certificate](https://github.com/nesk/covid-19-certificate) de [Johann Pardanaud](https://github.com/nesk). Le générateur d'attestation pour le [couvre-feu](https://github.com/LAB-MI/attestation-couvre-feu-covid-19) est postérieur à [deplacement-covid-19](https://github.com/nesk/deplacement-covid-19) et antérieur au dépôt actuel, il ne doit plus être utilisé.
+Ce projet a été réalisé à partir d'un fork du dépôt [deplacement-covid-19](https://github.com/nesk/deplacement-covid-19) lui-même réalisé à partir d'un fork du dépôt [covid-19-certificate](https://github.com/nesk/covid-19-certificate) de [Johann Pardanaud](https://github.com/nesk). Le générateur d'attestation pour le [couvre-feu](https://github.com/LAB-MI/attestation-couvre-feu-covid-19) est postérieur à [deplacement-covid-19](https://github.com/nesk/deplacement-covid-19) et antérieur au dépôt actuel, il ne doit plus être utilisé.
 
 Ce générateur est par ailleurs utilisable [en ligne](https://media.interieur.gouv.fr/deplacement-covid-19).
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ Le code à déployer sera le contenu du dossier `dist`
 
 ## Crédits
 
-Ce projet a été réalisé à partir d'un fork du dépôt [deplacement-covid-19](https://github.com/nesk/deplacement-covid-19) de lui-même réalisé à partir d'un fork du dépôt [covid-19-certificate](https://github.com/nesk/covid-19-certificate) de [Johann Pardanaud](https://github.com/nesk).
+Ce projet a été réalisé à partir d'un fork du dépôt [deplacement-covid-19](https://github.com/nesk/deplacement-covid-19) de lui-même réalisé à partir d'un fork du dépôt [covid-19-certificate](https://github.com/nesk/covid-19-certificate) de [Johann Pardanaud](https://github.com/nesk). Le générateur d'attestation pour le [couvre-feu](https://github.com/LAB-MI/attestation-couvre-feu-covid-19) est postérieur à [deplacement-covid-19](https://github.com/nesk/deplacement-covid-19) et antérieur au dépôt actuel, il ne doit plus être utilisé.
+
+Ce générateur est par ailleurs utilisable [en ligne](https://media.interieur.gouv.fr/deplacement-covid-19).
+
+Les modèles d'attestation sont disponibles [ICI](https://www.gouvernement.fr/info-coronavirus/ressources-a-partager) et [LA](https://www.interieur.gouv.fr/Actualites/L-actu-du-Ministere/Attestations-de-deplacement).
 
 Les projets open source suivants ont été utilisés pour le développement de ce
 service :


### PR DESCRIPTION
cf. https://github.com/LAB-MI/attestation-deplacement-derogatoire-q4-2020/issues/40#issuecomment-719651552

Ajout d'informations permettant de clairement identifier les repos précédents ainsi que la source des modèles PDF utilisés et du générateur officiel en ligne.