### PR TITLE
POC: store form data in localStorage

### DIFF
--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -71,6 +71,14 @@ export function getProfile (formInputs) {
   return fields
 }
 
+function storeProfile (profile) {
+  localStorage.setItem('profile', JSON.stringify(profile))
+}
+export function getStoredProfile () {
+  const storedProfile = localStorage.getItem('profile')
+  return storedProfile ? JSON.parse(storedProfile) : {}
+}
+
 export function getReasons (reasonInputs) {
   const reasons = reasonInputs
     .filter(input => input.checked)
@@ -128,6 +136,8 @@ export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonA
     }
 
     console.log(getProfile(formInputs), reasons)
+
+    storeProfile(getProfile(formInputs))
 
     const pdfBlob = await generatePdf(getProfile(formInputs), reasons, pdfBase)
 

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -6,6 +6,8 @@ import formData from '../form-data.json'
 
 import { $, appendTo, createElement } from './dom-utils'
 
+import { getStoredProfile } from './form-util'
+
 const createTitle = () => {
   const h2 = createElement('h2', { className: 'titre-2', innerHTML: 'Remplissez en ligne votre déclaration numérique : ' })
   const p = createElement('p', { className: 'msg-info', innerHTML: 'Tous les champs sont obligatoires.' })
@@ -41,6 +43,7 @@ const createFormGroup = ({
   const labelEl = createElement('label', labelAttrs)
 
   const inputGroup = createElement('div', { className: 'input-group align-items-center' })
+  const storedProfile = getStoredProfile()
   const inputAttrs = {
     autocomplete,
     autofocus,
@@ -56,6 +59,7 @@ const createFormGroup = ({
     placeholder,
     required: true,
     type,
+    value: storedProfile[name] || '',
   }
 
   const input = createElement('input', inputAttrs)


### PR DESCRIPTION
Un Proof of Concept pour stocker la saisie en localStorage, afin de la rappeler pour pré-remplir le formulaire une fois une génération d'attestation faite.
J'imagine qu'il faudrait pouvoir rendre ce stockage optionnel et en opt-in, ajouter un texte qui explique que les données sont stockées en local uniquement et sont accessibles par toute personne qui a accès au device, un bouton pour supprimer les données ou un système pour les faire expirer, un chiffrement...
Qu'en pensez-vous ? 