### PR TITLE
La date de création du QR code n'est pas antidatable

### DIFF
--- a/src/js/pdf-util.js
+++ b/src/js/pdf-util.js
@@ -16,9 +16,7 @@ const ys = {
 export async function generatePdf (profile, reasons, pdfBase) {
   const creationInstant = new Date()
   const creationDate = creationInstant.toLocaleDateString('fr-FR')
-  const creationHour = creationInstant
-    .toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
-    .replace(':', 'h')
+  const creationHour = profile.heuresortie.replace(':', 'h')
 
   const {
     lastname,


### PR DESCRIPTION
A l'heure actuelle il est possible de saisir une date/heure dans le passé dans le formulaire. Laissant croire aux citoyens qu'il est possible d'antidater une attestation. Hors, le QR code généré contiens une date de création utilisant l'heure courante. Ainsi, un citoyen ayant généré une attestation antidatée **avec l'application officielle** s'expose à une verbalisation en cas de contrôle. Ceci n'est pas acceptable.

Le plus simple,  tout en évitant toujours plus d'infantilisation, est de permettre aux citoyens d'antidater l'heure de création de l'attestation. C'est ce que propose ce patch simpliste.
