### PR TITLE
Correction de l'erreur de service worker

### DIFF
--- a/src/js/check-updates.js
+++ b/src/js/check-updates.js
@@ -1,12 +1,14 @@
 import { $ } from './dom-utils'
 
 // Ce fichier est généré au build par le plugin parcel-plugin-sw-cache
-const swName = '../sw.js'
+const path = window.location.pathname
+const swName = `${window.location}sw.js`
+
 window.isUpdateAvailable = new Promise(function (resolve, reject) {
   // lazy way of disabling service workers while developing
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker
-      .register(swName)
+    navigator.serviceWorkers
+      .register(swName, { scope: path })
       .then((registration) => {
         registration.onupdatefound = () => {
           const installingWorker = registration.installing

--- a/src/js/check-updates.js
+++ b/src/js/check-updates.js
@@ -7,7 +7,7 @@ const swName = `${window.location}sw.js`
 window.isUpdateAvailable = new Promise(function (resolve, reject) {
   // lazy way of disabling service workers while developing
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorkers
+    navigator.serviceWorker
       .register(swName, { scope: path })
       .then((registration) => {
         registration.onupdatefound = () => {

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -14,8 +14,8 @@ const createTitle = () => {
 // createElement('div', { className: 'form-group' })
 
 const getCurrentTime = () => {
-  const date = new Date();
-  return date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+  const date = new Date()
+  return date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
 }
 
 const createFormGroup = ({


### PR DESCRIPTION
Le chargement de l'application provoque une erreur au niveau du service worker

`VM13 main.d56e3230.js:27 [SW ERROR] TypeError: Failed to register a ServiceWorker for scope ('https://media.interieur.gouv.fr/') with script ('https://media.interieur.gouv.fr/sw.js'): A bad HTTP response code (404) was received when fetching the script.`

Cette PR prend en compte le chemin de l'application pour l'enregistrement du service worker ce qui lui permet de fonctionner depuis un sous répertoire