### PR TITLE
ne pas inclure les icones fa inutilises 

### DIFF
--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1,5 +1,5 @@
 import { library, dom } from '@fortawesome/fontawesome-svg-core'
-import { faFilePdf } from '@fortawesome/free-solid-svg-icons'
+import { faFilePdf } from '@fortawesome/free-solid-svg-icons/faFilePdf'
 
 library.add(faFilePdf)
 


### PR DESCRIPTION
Permet de reduire la taille du bundle js de plus de 50%, appreciable pour les petites connections ( type mobile )

on passe de
```
dist/main.46abc703.js                                     ⚠️  1.31 MB    376ms
```

```
dist/main.3b0166a3.js                                      656.03 KB    373ms
```