### PR TITLE
feat: ajout du localstorage et du remplissage automatique

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "attestation-derogatoire-de-deplacement",
-  "version": "1.0.6",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -5,6 +5,9 @@ import { addSlash, getFormattedDate } from './util'
 import pdfBase from '../certificate.pdf'
 import { generatePdf } from './pdf-util'
 
+// Les types d'input qu'on peut sauvegarder dans le storage
+const savableInputsTypes = ['text', 'number']
+
 const conditions = {
   '#field-firstname': {
     length: 1,
@@ -90,10 +93,16 @@ export function getReasons (reasonInputs) {
   return reasons
 }
 
-export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar) {
+export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar, storage) {
   formInputs.forEach((input) => {
     const exempleElt = input.parentNode.parentNode.querySelector('.exemple')
     const validitySpan = input.parentNode.parentNode.querySelector('.validity')
+    input.addEventListener('change', event => {
+      const { value, name, type } = event.target
+      if (savableInputsTypes.includes(type)) {
+        storage.setItem(name, value)
+      }
+    })
     if (input.placeholder && exempleElt) {
       input.addEventListener('input', (event) => {
         if (input.value) {
@@ -159,7 +168,7 @@ export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonA
   })
 }
 
-export function prepareForm () {
+export function prepareForm (storage) {
   const formInputs = $$('#form-profile input')
   const snackbar = $('#snackbar')
   const reasonInputs = [...$$('input[name="field-reason"]')]
@@ -167,5 +176,5 @@ export function prepareForm () {
   const reasonAlert = reasonFieldset.querySelector('.msg-alert')
   const releaseDateInput = $('#field-datesortie')
   setReleaseDateTime(releaseDateInput)
-  prepareInputs(formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar)
+  prepareInputs(formInputs, reasonInputs, reasonFieldset, reasonAlert, snackbar, storage)
 }

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -31,6 +31,7 @@ const createFormGroup = ({
   pattern,
   placeholder = '',
   type = 'text',
+  value = '',
 }) => {
   const formGroup = createElement('div', { className: 'form-group' })
   const labelAttrs = {
@@ -56,6 +57,7 @@ const createFormGroup = ({
     placeholder,
     required: true,
     type,
+    value,
   }
 
   const input = createElement('input', inputAttrs)
@@ -133,7 +135,7 @@ const createReasonFieldset = (reasonsData) => {
   return fieldset
 }
 
-export function createForm () {
+export function createForm (storage) {
   const form = $('#form-profile')
   // Évite de recréer le formulaire s'il est déjà créé par react-snap (ou un autre outil de prerender)
   if (form.innerHTML !== '') {
@@ -141,7 +143,6 @@ export function createForm () {
   }
 
   const appendToForm = appendTo(form)
-
   const formFirstPart = formData
     .flat(1)
     .filter(field => field.key !== 'reason')
@@ -152,6 +153,7 @@ export function createForm () {
         autofocus: index === 0,
         ...field,
         name: field.key,
+        value: storage.getItem(field.key),
       })
 
       return formGroup

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,8 +8,10 @@ import { prepareForm } from './form-util'
 import { warnFacebookBrowserUserIfNecessary } from './facebook-util'
 import { addVersion } from './util'
 import { createForm } from './form'
+import WindowStorage, { LOCAL_STORAGE } from './storage-helper'
 
+const storage = new WindowStorage('attestation_ministere', LOCAL_STORAGE)
 warnFacebookBrowserUserIfNecessary()
-createForm()
-prepareForm()
+createForm(storage)
+prepareForm(storage)
 addVersion(process.env.VERSION)

--- a/src/js/storage-helper.js
+++ b/src/js/storage-helper.js
@@ -1,0 +1,55 @@
+export const SESSION_STORAGE = 'sessionStorage'
+export const LOCAL_STORAGE = 'localStorage'
+
+const storages = [SESSION_STORAGE, LOCAL_STORAGE]
+
+class Storage {
+  constructor (key, storageType = SESSION_STORAGE) {
+    if (!storageType.includes(storages)) {
+      this.storageType = SESSION_STORAGE
+    }
+    this.key = key
+    this.storageType = storageType
+    this.init()
+  }
+
+  init () {
+    if (!window[this.storageType].getItem(this.key)) {
+      window[this.storageType].setItem(this.key, JSON.stringify({}))
+    }
+  }
+
+  /**
+   * Private method to get storage
+   * @returns {Object} parsed storage
+   */
+  getStorage () {
+    return JSON.parse(window[this.storageType].getItem(this.key))
+  }
+
+  /**
+   * Private method to update storage with an object
+   * @param {Object} obj
+   */
+  setStorage (obj) {
+    window[this.storageType].setItem(this.key, JSON.stringify(obj))
+  }
+
+  setItem (key, value) {
+    const previousStorage = this.getStorage()
+    previousStorage[key] = value
+    this.setStorage(previousStorage)
+  }
+
+  getItem (key) {
+    const storage = this.getStorage()
+    return storage[key]
+  }
+
+  clearStorage () {
+    window[this.storageType].removeItem(this.key)
+    this.init()
+  }
+}
+
+export default Storage


### PR DESCRIPTION
Ajout d'un localStorage permettant de sauvegarder les données des input de type `text` et `number`.  
  
On a la possibilité d'utiliser le `sessionStorage` pour la session et les rafraichissement pour éviter de perdre toutes les données lorsqu'on refresh la page surtout avec le bandeau de nouvelle version ou alors le `localStorage` pour persister la donnée dans le navigateur du client.  

it resolve #101