### PR TITLE
fix: "téléphone" remplacé par "appareil"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -70,7 +70,7 @@
                         value="storedata">
                 <label class="form-check-label"
                         for="field-storedata">
-                        Mon téléphone se souvient de moi
+                        Mon appareil se souvient de moi
                 </label>
             </div>
             <p class="text-center mt-5">
@@ -91,7 +91,7 @@
                     <span>
                     <i class="fa fa-trash inline-block mr-1"></i>
                     Effacer le formulaire et son
-                    contenu sauvegardé sur mon téléphone
+                    contenu sauvegardé sur mon appareil
                     </span>
                 </button>
             </p>


### PR DESCRIPTION
Les utilisateurs pouvant utiliser ce service depuis un ordinateur, une tablette ou un téléphone, il est plus exact d'utiliser un terme générique, comme "appareil", plutôt que d'opter pour le cas probablement majoritaire en pratique de "téléphone". De plus, le terme "appareil" a été préféré à "dispositif" ou "terminal" car il est plus concret et a priori plus immédiatement compréhensible par le grand public.