### PR TITLE
Fix issue #73 date de naissance

### DIFF
--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -155,7 +155,7 @@ export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonA
     }
   })
 
-  $('#field-birthday').addEventListener('keyup', function (event) {
+  $('#field-birthday').addEventListener('input', function (event) {
     event.preventDefault()
     const input = event.target
     const key = event.keyCode || event.charCode


### PR DESCRIPTION
Comme decrit dans issue #73, les chiffres entrés pour date du mois, ou mois d'année sont reportés dans le champ suivant (mois ou annee) sur certains navigateurs mobiles. Par exemple, en entrant 15 puis 0, le champ affiche 15/150, au lieu de 15/0. Problème reproduit et fixe verifiée sur Samsung Internet v12.1.4.3 et Chrome v84.0.4147.89 sur Samsung Galaxy S4 et S5. Non regression verifiée sur Chrome 86.0.4240.111 et FireFox 82.0.2 sur PC Windows 10.