### PR TITLE
Only show update popup if update is available

### DIFF
--- a/src/js/check-updates.js
+++ b/src/js/check-updates.js
@@ -32,6 +32,8 @@ window.isUpdateAvailable = new Promise(function (resolve, reject) {
 })
 
 window.isUpdateAvailable.then((isAvailable) => {
-  $('#reload-btn').addEventListener('click', () => window.location.reload())
-  $('#update-alert').classList.remove('d-none')
+  if(isAvailable) {
+    $('#reload-btn').addEventListener('click', () => window.location.reload())
+    $('#update-alert').classList.remove('d-none')
+  }
 })


### PR DESCRIPTION
Actuellement le front cherche s'il y a une màj de dispo même si on est dans un navigateur (ie. pas dans une PWA). Ce qui n'a pas de sens.

Cette PR permet de ne pas faire la recherche de màj si la page est affichée dans un navigateur. Au passage elle fix la fonction 

```js
window.isUpdateAvailable.then((isAvailable) => {
  if(isAvailable) {
    $('#reload-btn').addEventListener('click', () => window.location.reload())
    $('#update-alert').classList.remove('d-none')
  }
})
```

qui ne prenait pas en compte `isAvailable`.