### PR TITLE
Add a preview of 1 km circle for sport and animals

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ service :
 - [qrcode](https://github.com/soldair/node-qrcode)
 - [Bootstrap](https://getbootstrap.com/)
 - [Font Awesome](https://fontawesome.com/license)
+- [Leaflet](https://github.com/Leaflet/Leaflet/blob/master/LICENSE)
+- [OpenStreetMap](https://www.openstreetmap.org/copyright)

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -79,6 +79,10 @@ svg {
   height: 1em;
 }
 
+#osm-zone svg {
+    height: initial;
+}
+
 h1.flex.flex-wrap {
   display: flex;
   flex-wrap: wrap;

--- a/src/index.html
+++ b/src/index.html
@@ -26,6 +26,27 @@
     <link rel="manifest" href="./favicons/site.webmanifest">
     <link rel="mask-icon" href="./favicons/safari-pinned-tab.svg" color="#21bf73">
 
+    <!-- Load Leaflet from CDN -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+        integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+        crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
+        integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
+        crossorigin=""></script>
+
+    <!-- Load Esri Leaflet from CDN -->
+    <script src="https://unpkg.com/esri-leaflet@2.5.0/dist/esri-leaflet.js"
+        integrity="sha512-ucw7Grpc+iEQZa711gcjgMBnmd9qju1CICsRaryvX7HJklK0pGl/prxKvtHwpgm5ZHdvAil7YPxI1oWPOWK3UQ=="
+        crossorigin=""></script>
+
+    <!-- Load Esri Leaflet Geocoder from CDN -->
+    <link rel="stylesheet" href="https://unpkg.com/esri-leaflet-geocoder@2.3.3/dist/esri-leaflet-geocoder.css"
+        integrity="sha512-IM3Hs+feyi40yZhDH6kV8vQMg4Fh20s9OzInIIAc4nx7aMYMfo+IenRUekoYsHZqGkREUgx0VvlEsgm7nCDW9g=="
+        crossorigin="">
+    <script src="https://unpkg.com/esri-leaflet-geocoder@2.3.3/dist/esri-leaflet-geocoder.js"
+        integrity="sha512-HrFUyCEtIpxZloTgEKKMq4RFYhxjJkCiF5sDxuAokklOeZ68U2NPfh4MFtyIVWlsKtVbK5GD2/JzFyAfvT5ejA=="
+        crossorigin=""></script>
+
     <title>Attestation de déplacement dérogatoire</title>
 </head>
 <body>

--- a/src/js/form.js
+++ b/src/js/form.js
@@ -5,6 +5,7 @@ import '../css/main.css'
 import formData from '../form-data.json'
 
 import { $, appendTo, createElement } from './dom-utils'
+import { appendMap } from './osm-zone'
 
 const createTitle = () => {
   const h2 = createElement('h2', { className: 'titre-2', innerHTML: 'Remplissez en ligne votre déclaration numérique : ' })
@@ -157,4 +158,6 @@ export function createForm () {
 
   const reasonFieldset = createReasonFieldset(reasonsData)
   appendToForm([...createTitle(), ...formFirstPart, reasonFieldset])
+
+  appendMap()
 }

--- a/src/js/osm-zone.js
+++ b/src/js/osm-zone.js
@@ -1,0 +1,102 @@
+
+/**
+ * OSM example here: http://esri.github.io/esri-leaflet/examples/geocoding-control.html
+ */
+
+// France bounding rect
+const southWest = L.latLng(42.144314, -5.428104);
+const northEast = L.latLng(51.369423, 9.029903);
+const franceBounds = L.latLngBounds(southWest, northEast); // métropole
+
+// add a hidden div with id 'osm-zone'
+function addHtmlElement() {
+  const checkboxWithMap = document.querySelector('.form-checkbox [for="checkbox-sport_animaux"]')
+  const mapHtmlElement = document.createElement('div')
+  mapHtmlElement.id = 'osm-zone'
+  mapHtmlElement.style.height = '400px'
+  checkboxWithMap.parentNode.insertBefore(mapHtmlElement, checkboxWithMap.nextSibling);
+}
+
+function setupLeaflet() {
+  // setup leaflet and center on Nantes
+  const map = L.map('osm-zone', {scrollWheelZoom: 'center'}).setView([47.2173, -1.5534], 12)
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
+  }).addTo(map)
+
+  // init search form
+  const searchControl = L.esri.Geocoding.geosearch({ zoomToResult: false, searchBounds: franceBounds }).addTo(map)
+  const results = L.layerGroup().addTo(map)
+  searchControl.on('results', function (data) {
+    results.clearLayers()
+    for (let i = data.results.length - 1; i >= 0; i--) {
+      results.addLayer(L.marker(data.results[i].latlng))
+    }
+    map.setView(data.results[0].latlng, 13)
+  });
+
+  // create a circle in the center of map
+  const circle = L.circle(map.getCenter(), {
+    radius: 1000,
+    color: 'red',
+    weight: 1,
+    fillOpacity: 0.15,
+  }).addTo(map)
+
+  // move circle with the map
+  map.on('move', (e) => {
+    circle.setLatLng(map.getCenter())
+    map._renderer._update()
+  })
+
+  goToFormAddress(map)
+
+  window.MAP = map // debug
+}
+
+// when address is set into the form, we center the map to this addresse
+function goToFormAddress(map) {
+  const address = document.getElementById('field-address').value
+  const city = document.getElementById('field-city').value
+
+  if (address == '' && city == '')
+      return;
+
+  const geocode = L.esri.Geocoding.geocode()
+
+  if (!!address && address.length) geocode.address(address)
+  if (!!city && city.length) geocode.city(city)
+
+  geocode.within(franceBounds).country('France').run((err, response) => {
+    if (err) {
+      console.error(err)
+      return
+    }
+
+    if (response.results.length == 0)
+      return
+    
+    const latlng = response.results[0].latlng
+    // map.flyTo(latlng, 13, {duration: 1})
+    map.setView(latlng, 13);
+  })
+}
+
+function closeLeaflet() {
+  document.getElementById('osm-zone').remove();
+}
+
+function onCheckboxSwitched() {
+  // show/hide map on checkbox selection
+  if (this.checked) {
+    addHtmlElement()
+    setupLeaflet();
+  }
+  else {
+    closeLeaflet();
+  }
+}
+
+export function appendMap() {
+  document.getElementById('checkbox-sport_animaux').addEventListener('change', onCheckboxSwitched);
+};


### PR DESCRIPTION
When you click on "sport and animals" checkbox, a map is displayed, with a preview of the 1 km circle.

![image](https://user-images.githubusercontent.com/2951285/98311719-5da9cd80-1fd0-11eb-938f-329878d62cb3.png)

If you previously filled the form with address + city, we center the map on your address.

Based on OSM maps and Leaflet lib.
