### PR TITLE
Auto-génération de l'attestation

### DIFF
--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -207,6 +207,17 @@ export function prepareInputs (formInputs, reasonInputs, reasonFieldset, reasonA
     downloadBlob(pdfBlob, `attestation-${creationDate}_${creationHour}.pdf`)
     showSnackbar(snackbar, 6000)
   })
+
+  // Si on passe un motif en query string, on pré-remplit et on génère eautomatiquement le formulaire.
+  const motifs = ['travail', 'achats', 'sante', 'famille', 'handicap', 'sport_animaux', 'convocation', 'missions', 'enfants']
+  const urlParams = new URLSearchParams(window.location.search)
+  const motif = urlParams.get('motif')
+
+  if (motif && motifs.includes(motif)) {
+    $('#checkbox-' + motif).checked = true
+    $('#field-heuresortie').value = new Date().toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+    document.getElementById('generate-btn').click()
+  }
 }
 
 export function prepareForm () {


### PR DESCRIPTION
Utilisation des query strings pour générer automatiquement le pdf à l'ouverture de la page.

Cela permettrait d'ajouter des liens sur le téléphone pour générer l'attestation rapidement et en 1 clic. Pour ma part, je génère régulièrement la même attestation pour les achats de première nécessité.

Ceci est un changement très simple, sans envoi de donnée personnelle au serveur, sachant que la plupart des personnes conservent leurs données personnelles stockées pour ne plus à avoir à les retaper..

Je sais qu'il existe déjà une PR proposant la même fonctionnalité : #https://github.com/LAB-MI/attestation-deplacement-derogatoire-q4-2020/pull/50
J'espère qu'au moins l'une d'entre ces PRs sera validée !