### PR TITLE
Changement des checkbox en radio button pour choix unique

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -82,7 +82,7 @@ const createReasonField = (reasonData) => {
   const id = `checkbox-${reasonData.code}`
   const inputReasonAttrs = {
     className: 'form-check-input',
-    type: 'checkbox',
+    type: 'radio',
     id,
     name: 'field-reason',
     value: reasonData.code,


### PR DESCRIPTION
Bonjour à tous, tout d'abord merci pour cet outil fort utile et économe en papier.

Petite modification qui me semble essentielle : pour l'instant, il est possible de sélectionner plusieurs raisons de sortie (testé sur webkit et firefox). Hors, il est indiqué sur l'attestation : "lié **au** motif suivant". J'en déduis donc qu'il ne doit être possible d'en sélectionner qu'une seule.

La modification que je propose permet de limiter le choix à un seul motif.

Bonne journée !